### PR TITLE
Changed logging to syslog, avoiding log file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,7 +54,7 @@ bdeps-test = procps, psmisc, miscfiles
 CDBS_BUILD_DEPENDS +=, $(deps-dev), $(bdeps-test)
 CDBS_DEPENDS_$(pkg-dev) +=, $(deps-dev)
 
-DEB_CONFIGURE_EXTRA_FLAGS = --disable-log-stdout --with-log-file='/var/log/libsrtp.log' --enable-openssl
+DEB_CONFIGURE_EXTRA_FLAGS = --disable-stdout --enable-syslog --enable-openssl
 ifneq (,$(findstring debug,$(DEB_BUILD_OPTIONS)))
 DEB_CONFIGURE_EXTRA_FLAGS += --enable-debug-logging
 else
@@ -99,6 +99,7 @@ binary-post-install/$(pkg-lib)::
 	d-shlibmove --commit \
 		--devunversioned \
 		--multiarch \
+		--override s/libssl-dev// \
 		--movedev "debian/tmp/usr/include/*" usr/include/ \
 		--movedev "debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/*" \
 			usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig \


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
No new behaviour, just fixing a bug, libsrtp was using a log file that may cause problems with ownership and permissions. So we changed it to syslog to avoid that.

## What is the new behavior provided by this change?
Log is not output to a log file but to syslog (as in previous libsrtp fork in kurento)

## How has this been tested?
Compilation and unit tests executd and verified

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [X] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
